### PR TITLE
Update eslint versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "eslint": "^2.1.0",
-    "eslint-config-clock": "^1.0.1",
+    "eslint-config-clock": "^1.0.2",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-standard": "^1.3.1",
     "lodash.template": "^3.6.2",

--- a/templates/package.json.tpl
+++ b/templates/package.json.tpl
@@ -25,7 +25,7 @@
     "cf-changelog": "^1.0.0",
     "depcheck": "^0.4.7",
     "eslint": "^2.1.0",
-    "eslint-config-clock": "^1.0.1",
+    "eslint-config-clock": "^1.0.2",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-standard": "^1.3.1",
     "glob": "^5.0.14",


### PR DESCRIPTION
Updates - 
- generator eslint dependencies versions
- generated eslint dependencies versions

This stops the following error on npm install on generator projects, caused by https://github.com/clocklimited/eslint-config-clock/commit/814dfbe4a81ccac816fa669870b5314272314a18.

```
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package eslint-config-standard@4.4.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-config-clock@1.0.1 wants eslint-config-standard@^5.1.0
```
